### PR TITLE
Feature: Mesh support & new RenderPipeline3D

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,17 @@
 
 `g++ ./src/main.cpp ./src/Math.cpp ./src/RenderPipeline3D.cpp -o ./bin/main.exe -O3`
 
+2018/07/05
+- Added `MESH` to represent polygons and primitives.
+- `RenderPipeline3D` is refactored to support the new `MESH` structure.
+- Meshes to be rendered **MUST** be triangles. Polygon face is not supported yet.
+
 # TODO
 
-2018/07/04 
-1. 产生基本几何体，共用公共顶点，使用顶点index标记多边形；
+1. ~~共用公共顶点，使用顶点index标记多边形；~~
+1. 增加更多几何体，立方体、球、圆柱、犹他茶壶；
 1. 规范化输入到渲染管线的数据结构，将材质、贴图、几何体的信息集成输入渲染管线；
 1. 增加聚光灯、平行光等新的光线类型；
 1. 增加图片纹理贴图；
-1. 修改三角形填充算法实现，提高性能；
+1. ~~修改三角形填充算法实现，提高性能；~~
 1. 增加多边形裁剪。

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,116 +29,65 @@ SOFTWARE.
 using namespace pixpix;
 using namespace std;
 
-VERTEX3 getVertex(VEC3 pos, VEC2 tex_coord) {
-    VERTEX3 vt;
-    vt.pos = pos;
-    vt.tex_coord = tex_coord;
-    vt.color = {0.0, 0.0, 0.0, 1.0};
-    vt.normal = {0.0, 0.0, 0.0};
-    return vt;
-}
-
-void drawSphere(RenderPipeline3D *pipeline, float r, unsigned w, unsigned h, VEC3 position, VEC3 rotation) {
-    MATRIX4 m_rot = Math::pitch_yaw_roll(rotation.y, rotation.x, rotation.z),
-            m_trans = Math::translation(position.x, position.y, position.z),
-            m_comp = Math::matrixMul(m_trans, m_rot);
-    
-    vector<VERTEX3> *vertex = new vector<VERTEX3>;
-
-    float d_theta = Math::Pi * 2.0f / w;
-    float d_alpha = Math::Pi / h;
-    for (int i = 0; i < w; ++i) {
-        for (int j = 0; j < h; ++j) {
-            float theta[] = {d_theta * i, d_theta * (i + 1)};
-            float alpha[] = {Math::Pi/2.0f-d_alpha * j, Math::Pi/2.0f-d_alpha * (j + 1)};
-#define GPOS(t, a) ((VEC4){ cos(t)*cos(a), sin(t)*cos(a), sin(a), 1.0f })
-            VEC3 normal, pos;
-            VEC4 normalH, posH;
-            VEC2 tex_coord;
-            VERTEX3 ver[4];
-            for (int u = 0; u < 2; ++u)
-                for (int v = 0; v < 2; ++v) {
-                    normalH = GPOS(theta[u], alpha[v]);
-                    posH = normalH * r; posH.w = 1.0;
-                    normalH = Math::matrixVecMul(m_rot, normalH);
-                    normalH.regularize();
-                    posH = Math::matrixVecMul(m_comp, posH);
-                    posH.regularize();
-                    normal = (VEC3){normalH.x, normalH.y, normalH.z};
-                    pos = (VEC3){posH.x, posH.y, posH.z};
-                    tex_coord = (VEC2){1.0f/w*(i+u), 1.0f/h*(j+v)};
-                    // printf("%f %f\n", tex_coord.x, tex_coord.y);
-                    VERTEX3 &cur_ver = ver[v*2+u];
-                    cur_ver.normal = normal;
-                    cur_ver.pos = pos;
-                    cur_ver.tex_coord = tex_coord;
-                }
-            vertex->push_back(ver[0]);
-            vertex->push_back(ver[2]);
-            vertex->push_back(ver[3]);
-            vertex->push_back(ver[0]);
-            vertex->push_back(ver[3]);
-            vertex->push_back(ver[1]);
-#undef GPOS
-        }
-    }
-    pipeline->render(vertex);
-    delete vertex;
-}
-
 void drawPlane(RenderPipeline3D *pipeline, float w, float h, VEC3 position, VEC3 rotation) {
-    vector<VERTEX3> *vertex = new vector<VERTEX3>;
-    VERTEX3 va = getVertex( {-w/2.0f, h/2.0f, 0.0f}, {0.0f, 0.0f} ),
-            vb = getVertex( {w/2.0f, h/2.0f, 0.0f}, {1.0f, 0.0f} ),
-            vc = getVertex( {-w/2.0f, -h/2.0f, 0.0f}, {0.0f, 1.0f} ),
-            vd = getVertex( {w/2.0f, -h/2.0f, 0.0f}, {1.0f, 1.0f} );
-    vertex->push_back(va);
-    vertex->push_back(vc);
-    vertex->push_back(vd);
-    vertex->push_back(va);
-    vertex->push_back(vd);
-    vertex->push_back(vb);
-
+    VEC3 verts[4] = {
+        (VEC3){-w/2.0f, h/2.0f, 0},
+        (VEC3){w/2.0f, h/2.0f, 0},
+        (VEC3){-w/2.0f, -h/2.0f, 0},
+        (VEC3){w/2.0f, -h/2.0f, 0}
+    };
+    unsigned faceIndex[] = {3, 3};
+    unsigned vertexIndex[] = {0, 2, 3, 0, 3, 1};
+    VEC2 texCoord[] = {
+        (VEC2){0.0f, 0.0f}, (VEC2){0.0f, 1.0f}, (VEC2){1.0f, 1.0f},
+        (VEC2){0.0f, 0.0f}, (VEC2){1.0f, 1.0f}, (VEC2){1.0f, 0.0f}};
+    
     MATRIX4 m_rot = Math::pitch_yaw_roll(rotation.y, rotation.x, rotation.z),
-            m_trans = Math::translation(position.x, position.y, position.z),
-            m_comp = Math::matrixMul(m_trans, m_rot);
+        m_trans = Math::translation(position.x, position.y, position.z),
+        m_comp = Math::matrixMul(m_trans, m_rot);
+    /* vertex transformation */
+    for (size_t i = 0; i < 4; ++i) {
+        VEC4 v_tmp = {verts[i].x, verts[i].y, verts[i].z, 1.0f};
+        v_tmp = Math::matrixVecMul(m_comp, v_tmp);
+        v_tmp.regularize();
+        verts[i] = (VEC3){v_tmp.x, v_tmp.y, v_tmp.z};
+    }
+    
+    MESH mesh;
+    mesh.faceIndex = new vector<unsigned>(faceIndex, faceIndex+2);
+    mesh.vertexIndex = new vector<unsigned>(vertexIndex, vertexIndex+6);
+    mesh.normal = new vector<VEC3>(6, (VEC3){0, 0, 1.0});
+    mesh.texCoord = new vector<VEC2>(texCoord, texCoord+6);
+    mesh.verts = new vector<VEC3>(verts, verts+4);
 
-    for (int i = 0; i < vertex->size(); ++i) {
-        VERTEX3 &cur_vertex = (*vertex)[i];
-        VEC3 pos = cur_vertex.pos,
-             normal = {0.0f, 0.0f, 1.0f};
-        VEC4 posH = {pos.x, pos.y, pos.z, 1.0f},
-             normalH = {normal.x, normal.y, normal.z, 1.0f};
-        posH = Math::matrixVecMul(m_comp, posH);
-        posH.regularize();
-        normalH = Math::matrixVecMul(m_rot, normalH);
-        normalH.regularize();
-        
-        cur_vertex.pos = {posH.x, posH.y, posH.z};
-        cur_vertex.normal = {normalH.x, normalH.y, normalH.z};
+    /* normal transformation */
+    for (size_t i = 0; i < 6; ++i) {
+        VEC4 v_tmp = (VEC4){(*mesh.normal)[i].x, (*mesh.normal)[i].y, (*mesh.normal)[i].z, 1.0f};
+        v_tmp = Math::matrixVecMul(m_rot, v_tmp);
+        v_tmp.regularize();
+        (*mesh.normal)[i] = v_tmp;
     }
 
-    pipeline->render(vertex);
-    delete vertex;
+    pipeline->render(mesh);
 }
 
 int main() {
     /* testcode */
     const int W = 128, H = 64;
     CANVAS *cav = new CANVAS(W, H);
-    RenderPipeline3D *pipeline = new RenderPipeline3D();
-    vector<VERTEX3> vecs;
+    CAMERA *cam = new CAMERA();
+    RenderPipeline3D *pipeline = new RenderPipeline3D(cav, cam);
     TEXTURE *tex = new TEXTURE();
     LIGHT *lgt = new LIGHT();
     MATERIAL *mat = new MATERIAL();
 
-    pipeline->init(cav);
-    pipeline->camera->position = {4.0, 4.0, 4.0};
-    pipeline->camera->lookAt(0, 0, 0);
-    pipeline->camera->fovY = Math::Pi / 180.0f * 60.0f;
+    pipeline->init();
+    cam->position = {0.0f, 0.0f, 4.0f};
+    cam->lookAt(0, 0, 0);
+    cam->fovY = Math::Pi / 180.0f * 60.0f;
 
     tex->ty = T_CHESS_BOARD;
-    tex->sz = 8;
+    tex->sz = 4;
     tex->color1 = {0.2, 0.9, 0.1, 1.0};
     tex->color2 = {0.0, 0.1, 0.1, 1.0};
     
@@ -151,12 +100,11 @@ int main() {
     lgt->mPosition = {0.0f, 5.0f, 0.0f};
 
     mat->specularSmoothLevel = 100;
-
     for (int i = -30; ; ++i) {
         if (i > 30) i = -30;
-        pipeline->camera->position = {i / 10.0f, i / 10.0f, 4.0f};
-        pipeline->camera->lookAt(0, 0, 0);
-        pipeline->init(cav);
+        cam->position = {i / 10.0f, i / 10.0f, 4.0f};
+        cam->lookAt(0, 0, 0);
+        pipeline->init();
         pipeline->setMaterial(mat);
         //lgt->mPosition = {3.0f * cos(Math::Pi/60.0f*i), 3.0f, 3.0f * sin(Math::Pi/60.0f*i)};
         lgt->mAmbientColor = {0.1f, 0.1f, 0.1f};
@@ -168,10 +116,6 @@ int main() {
         lgt->mPosition = {-1.0f, -5.0f, 5.0f};
         pipeline->addLight(*lgt);
 
-        tex->color1 = {0.2, 1.0, 0.5, 1.0};
-        tex->color2 = {0.0, 0.5, 1.0, 1.0};
-        pipeline->setTexture(tex);
-        drawSphere(pipeline, 1.0f, 12, 6, {0,0,0}, {-Math::Pi/30.0f*i,Math::Pi/60.0f*i,Math::Pi/76.0f*i});
         tex->color1 = {1.0, 0.5, 0.5, 1.0};
         tex->color2 = {0.1, 0.1, 0.1, 1.0};
         pipeline->setTexture(tex);
@@ -180,7 +124,5 @@ int main() {
         cli_graph(W, H, cav->img);
         Sleep(50);
     }
-
-    //pipeline->render(&vecs);
     return 0;
 }

--- a/src/pixpix.h
+++ b/src/pixpix.h
@@ -272,29 +272,31 @@ struct MESH {
 */
 class RenderPipeline3D {
 private:
-    vector<VERTEX_RENDER> *vertex_homo;     /* homogeneous vertexes */
-    vector<VERTEX_RENDER> *vertex_homo_clipped;
+    // vector<VERTEX_RENDER> *vertex_homo;     /* homogeneous vertexes */
+    // vector<VERTEX_RENDER> *vertex_homo_clipped;
     vector<RASTERIZED_FRAGMENT> *fragment;  /* rasterized fragment  */
     vector<float> *zBuffer;                 /* z - buffer           */
     vector<LIGHT> *light;                   /* lights               */
-    CANVAS *cav;
+    CAMERA *camera;                         /* camera               */
+    CANVAS *canvas;                         /* pixel - buffer       */
 
     TEXTURE *texture;
     MATERIAL *material;
     
-    void bilinearInterpolation(VEC2, VEC2, VEC2, VEC2, float &, float &);
     COLOR4 getChessBoard(VEC2, unsigned, COLOR4, COLOR4);
+    void bilinearInterpolation(VEC2, VEC2, VEC2, VEC2, float &, float &);
     bool zBufferTest(RASTERIZED_FRAGMENT, float);
     void shadeFragment(RASTERIZED_FRAGMENT &, VEC3);
+    void renderTriangle(vector<VEC3> *verts, vector<VEC4> *verts_homo, vector<VEC3> *normal, vector<VEC2> *tex_coord, vector<unsigned> *tri_verts);
+    vector<VEC4> *getVertexClipSpace(vector<VEC3> *);
 public:
-    CAMERA *camera;                         /* camera */
-    RenderPipeline3D():camera(new CAMERA()), vertex_homo(nullptr), fragment(nullptr), zBuffer(nullptr), light(nullptr),  vertex_homo_clipped(nullptr) {}
+    RenderPipeline3D(CANVAS *cav, CAMERA *cam):camera(cam), canvas(cav), fragment(nullptr), zBuffer(nullptr), light(nullptr) {}
     
-    void init(CANVAS *);
+    void init();
     void setTexture(TEXTURE *);
     void setMaterial(MATERIAL *);
     void addLight(LIGHT);
-    void render(vector<VERTEX3> *);
+    void render(MESH);
 };
 
 }

--- a/src/pixpix.h
+++ b/src/pixpix.h
@@ -130,7 +130,7 @@ using COLOR4 = VEC4;    /* rgba */
 struct VERTEX3 {
     VEC3 pos;           /* position in 3d space */
     COLOR4 color;       /* rgba color           */
-    VEC3 normal;        /* normal of surface    */
+    // VEC3 normal;        /* normal of surface    */
     VEC2 tex_coord;     /* texture coordinate   */
 };
 
@@ -247,6 +247,20 @@ struct LIGHT {
     }
 };
 
+/* mesh 
+    contains a vertex list and a triangle list using index referring to 
+    the vertexs.
+*/
+struct MESH {
+    vector<VEC3> *verts;                    /* vertex list                    */
+    vector<unsigned> *faceIndex;            /* number of vertexes per face    */
+    vector<unsigned> *vertexIndex;          /* vertex index in the list above */
+    vector<VEC3> *normal;                   /* vertex normal                  */
+    vector<VEC2> *texCoord;                 /* vertex texture coordinates     */
+
+    MESH(): verts(nullptr), faceIndex(nullptr), vertexIndex(nullptr), 
+            normal(nullptr), texCoord(nullptr) {}
+};
 
 /* ============================================ */
 /*        Renderer, render pipelines            */


### PR DESCRIPTION
- Added `MESH` to represent polygons and primitives.
- `RenderPipeline3D` is refactored to support the new `MESH` structure.
- Meshes to be rendered **MUST** be triangles. Polygon face is not supported yet.